### PR TITLE
Removes existing Gen folder to avoid exception conflict.

### DIFF
--- a/generators/procedures/generator.js
+++ b/generators/procedures/generator.js
@@ -1,5 +1,6 @@
 var http = require('http');
 var fs = require('fs');
+var rmdir = require('rmdir');
 var procedures = require('./descriptions');
 
 var connection = require("../../api/dbConnection.js"); //instantiate connection provider
@@ -28,7 +29,8 @@ var exportedMain = function(_callback) {
 	var dbConfig = configuration.mysql;
 	var options = config.request;
 	exceptions = config.exceptions;
-	dir = __dirname + "/../../api/routes/gen/procedures";
+	genDir = __dirname + "/../../api/routes/gen";
+    dir = genDir + "/procedures";
 	callback = _callback;
 	connection.createPool(configuration); //initiate connection pool
 	procedures.getProcedures(connection, response, dbConfig.database);
@@ -37,6 +39,7 @@ exports.generate = exportedMain;
 
 // Main function
 function generate(procedures) {
+	rmdir(genDir); // Remove existing dir to avoid existing folders to be shown if new exceptions exist
 	mkdirp(dir);
 	for (i1 = 0; i1 < procedures.length; i1++) {
 		it: {
@@ -51,6 +54,8 @@ function generate(procedures) {
 	}
 	if (procedures.length) {
 		console.log("Procedures generation done.")
+    } else {
+        console.log("No procedures found. Skipping...")
 	};
 }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
         "cli": "^1.0.1",
         "express": "^4.10.6",
         "lodash": "^4.17.4",
-        "mysql": "^2.5.4"
+        "mysql": "^2.5.4",
+        "rmdir": "^1.2.0" 
     },
 	"preferGlobal": "true",
 	"bugs": "https://github.com/mlndz28/mysql-rest-api/issues",


### PR DESCRIPTION
If an already generated table or procedure is added to exceptions array in conf.json, after the new generation it would still be available.
Let's say I generate my api with Instrument table. Use it, kill the api. Next day I add Instrument to  exceptions, i wouldn't want it to be shown if I POST it. Without removing the gen folder or it's contents, it would.